### PR TITLE
Pukes an error message and exits on missing targets

### DIFF
--- a/smoketcp.go
+++ b/smoketcp.go
@@ -28,10 +28,8 @@ func doEvery(d time.Duration, f func(statsd.Statter, string, bool), s statsd.Sta
 func processTargets(s statsd.Statter, targetFile string, debug bool) {
 	content, err := ioutil.ReadFile(targetFile)
 	if err != nil {
-		if debug {
-			fmt.Println("couldn't open targets file:", targetFile)
-		}
-		return
+		fmt.Println("couldn't open targets file:", targetFile)
+		os.Exit(1)
 	}
 	targets := strings.Split(string(content), "\n")
 	for _, target := range targets {


### PR DESCRIPTION
If -debug isn't set, this fork of smoketcp will just silently hang if it can't find the targets file. With -debug set, it logs an error message and hangs.

This switches it to simply exit with a non-zero value in that case. 
